### PR TITLE
Create basic Babylon.js site

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,1 +1,27 @@
- 
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Babylon.js Site</title>
+    <style>
+        html, body {
+            overflow: hidden;
+            width: 100%;
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+        #renderCanvas {
+            width: 100%;
+            height: 100%;
+            touch-action: none;
+        }
+    </style>
+    <script src="https://cdn.babylonjs.com/babylon.js"></script>
+    <script src="https://cdn.babylonjs.com/loaders/babylonjs.loaders.min.js"></script>
+</head>
+<body>
+    <canvas id="renderCanvas"></canvas>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,67 @@
+const canvas = document.getElementById("renderCanvas");
+const engine = new BABYLON.Engine(canvas, true);
+
+const createScene = function () {
+    const scene = new BABYLON.Scene(engine);
+
+    // Camera
+    // Parameters: name, alpha, beta, radius, target position, scene
+    const camera = new BABYLON.ArcRotateCamera("camera", 0, 0, 0.1, new BABYLON.Vector3(0, 0, 0), scene);
+    // Positions the camera based on the example URL: -0.14,0.005,0.03
+    // Babylon's ArcRotateCamera is defined by alpha, beta, radius, and target.
+    // We'll set the position directly and then set the target.
+    camera.setPosition(new BABYLON.Vector3(-0.14, 0.005, 0.03));
+    camera.attachControl(canvas, true);
+
+    // Enable auto-rotation
+    camera.autoRotate = true;
+    camera.autoRotateSpeed = 0.5; // Adjust speed as needed
+
+    // Skybox
+    const skybox = BABYLON.MeshBuilder.CreateBox("skyBox", { size: 1000.0 }, scene);
+    const skyboxMaterial = new BABYLON.StandardMaterial("skyBoxMaterial", scene);
+    skyboxMaterial.backFaceCulling = false;
+    skyboxMaterial.reflectionTexture = new BABYLON.CubeTexture("https://assets.babylonjs.com/environments/studio.env", scene);
+    skyboxMaterial.reflectionTexture.coordinatesMode = BABYLON.Texture.SKYBOX_MODE;
+    skyboxMaterial.diffuseColor = new BABYLON.Color3(0, 0, 0);
+    skyboxMaterial.specularColor = new BABYLON.Color3(0, 0, 0);
+    skybox.material = skyboxMaterial;
+
+    // Model Loading
+    BABYLON.SceneLoader.ImportMesh("", "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MosquitoInAmber/glTF/", "MosquitoInAmber.gltf", scene, function (meshes) {
+        // Optional: scale or position the loaded model if necessary
+        // meshes[0].scaling = new BABYLON.Vector3(0.1, 0.1, 0.1);
+        // Ensure the camera is targeting the loaded model or a point of interest.
+        // If meshes exist, set camera target to the first mesh's position.
+        if (meshes.length > 0) {
+            let mainMesh = meshes[0];
+            // Attempt to center the camera target on the bounding box of the model
+            let boundingInfo = mainMesh.getHierarchyBoundingVectors();
+            let center = BABYLON.Vector3.Center(boundingInfo.min, boundingInfo.max);
+            camera.setTarget(center);
+
+            // Adjust camera radius based on model size if needed.
+            // This requires more complex calculation based on bounding sphere.
+            // For now, using the initial radius based on the example's camera position.
+            // The initial camera position (-0.14, 0.005, 0.03) suggests a very close view.
+            // We might need to adjust radius or field of view if the model is not visible.
+            // The example cameraPosition is very close to origin, let's assume the model is also near origin.
+        }
+    });
+
+    // Add a hemispheric light to ensure the model is visible
+    const light = new BABYLON.HemisphericLight("light", new BABYLON.Vector3(0, 1, 0), scene);
+    light.intensity = 0.7;
+
+    return scene;
+};
+
+const scene = createScene();
+
+engine.runRenderLoop(function () {
+    scene.render();
+});
+
+window.addEventListener("resize", function () {
+    engine.resize();
+});


### PR DESCRIPTION
This commit introduces a simple Babylon.js webpage consisting of an HTML file and a JavaScript file.

Features:
- `index.html`: Sets up the HTML structure with a canvas for rendering. Includes CDN links for Babylon.js and its loaders.
- `script.js`:
    - Initializes the Babylon.js engine and a scene.
    - Creates an ArcRotateCamera and sets its position to (-0.14, 0.005, 0.03) and targets the loaded model.
    - Enables auto-rotation for the camera.
    - Loads the 'MosquitoInAmber.gltf' model from the KhronosGroup GitHub repository.
    - Creates a skybox using the 'studio.env' environment map from assets.babylonjs.com.
    - Adds a HemisphericLight for basic scene illumination.
    - Handles window resizing to keep the scene responsive.

This setup mirrors the functionality of the example URL you provided in the issue, displaying a specific glTF model with a skybox, camera controls, and auto-rotation.