### PR TITLE
Update 3D model filename in Babylon.js scene

### DIFF
--- a/script.js
+++ b/script.js
@@ -28,7 +28,7 @@ const createScene = function () {
     skybox.material = skyboxMaterial;
 
     // Model Loading
-    BABYLON.SceneLoader.ImportMesh("", "", "HoodedCory_GoodNewHoodShiny_.FaceDark.glb", scene, function (meshes) {
+    BABYLON.SceneLoader.ImportMesh("", "", "HoodedCory_NewStart_NewHood_DecimatedCreasedHood-1.glb", scene, function (meshes) {
         // Optional: scale or position the loaded model if necessary
         // meshes[0].scaling = new BABYLON.Vector3(0.1, 0.1, 0.1);
         // Ensure the camera is targeting the loaded model or a point of interest.


### PR DESCRIPTION
I changed the glTF model loaded in `script.js`.

The filename in the `BABYLON.SceneLoader.ImportMesh` function was updated from 'HoodedCory_GoodNewHoodShiny_.FaceDark.glb' to 'HoodedCory_NewStart_NewHood_DecimatedCreasedHood-1.glb'.

The model is still loaded from the root of the repository, and all other scene settings (scaling, lighting, camera) remain unchanged.