### PR TITLE
feat: Add deep red spotlight above model

### DIFF
--- a/script.js
+++ b/script.js
@@ -100,6 +100,24 @@ const createScene = function () {
             // console.log("Model Dimension for Framing (Height/Width/Depth):", modelDimensionForFraming);
             // console.log("Calculated Camera Distance (Radius):", distance);
             // console.log("Camera FOV (radians):", camera.fov);
+
+            // Add a SpotLight
+            const spotLightPosition = new BABYLON.Vector3(modelCenter.x, modelCenter.y + 5, modelCenter.z);
+            const spotLightDirection = modelCenter.subtract(spotLightPosition).normalize(); // Direction from light position to model center
+
+            const spotLight = new BABYLON.SpotLight(
+                "spotLight",
+                spotLightPosition,
+                spotLightDirection,
+                5 * Math.PI / 180, // Angle in radians
+                2, // Exponent (falloff)
+                scene
+            );
+            spotLight.intensity = 75;
+            // Deep red color
+            const deepRedColor = new BABYLON.Color3(0.6, 0.1, 0.1);
+            spotLight.diffuse = deepRedColor;
+            spotLight.specular = deepRedColor;
         }
     });
 
@@ -111,12 +129,12 @@ const createScene = function () {
     // Light source is conceptually "slightly up, to the right, and slightly forward" from the model.
     // If model is at origin, source could be (5, 5, 5).
     // Direction of light rays is from source to target (model origin). So, (0-5, 0-5, 0-5) = (-5, -5, -5).
-    const directionalLight = new BABYLON.DirectionalLight("directionalLight", new BABYLON.Vector3(-1, -1, -1).normalize(), scene);
-    directionalLight.intensity = 0.8; // Medium intensity
-    directionalLight.diffuse = new BABYLON.Color3(1, 1, 1); // White light
-    directionalLight.specular = new BABYLON.Color3(1, 1, 1); // White highlights
-    // Set a conceptual position for the light source (e.g. for shadow maps if they were used)
-    directionalLight.position = new BABYLON.Vector3(5, 5, 5);
+    // const directionalLight = new BABYLON.DirectionalLight("directionalLight", new BABYLON.Vector3(-1, -1, -1).normalize(), scene);
+    // directionalLight.intensity = 0.8; // Medium intensity
+    // directionalLight.diffuse = new BABYLON.Color3(1, 1, 1); // White light
+    // directionalLight.specular = new BABYLON.Color3(1, 1, 1); // White highlights
+    // // Set a conceptual position for the light source (e.g. for shadow maps if they were used)
+    // directionalLight.position = new BABYLON.Vector3(5, 5, 5);
 
     return scene;
 };


### PR DESCRIPTION
This commit introduces a new spotlight to the scene:
- Type: BABYLON.SpotLight
- Position: 5 units directly above the center of the loaded model.
- Target: Center of the model.
- Angle: 5 degrees, creating a focused beam.
- Intensity: 75.
- Color: Deep red (diffuse and specular).

To ensure the spotlight's effect is prominent, the existing DirectionalLight has been commented out.