### PR TITLE
fix: Reposition spotlight closer to model as per your feedback

### DIFF
--- a/script.js
+++ b/script.js
@@ -102,7 +102,7 @@ const createScene = function () {
             // console.log("Camera FOV (radians):", camera.fov);
 
             // Add a SpotLight
-            const spotLightPosition = new BABYLON.Vector3(modelCenter.x, modelCenter.y + 5, modelCenter.z);
+            const spotLightPosition = new BABYLON.Vector3(0, 2, 0); // Fixed position
             const spotLightDirection = modelCenter.subtract(spotLightPosition).normalize(); // Direction from light position to model center
 
             const spotLight = new BABYLON.SpotLight(


### PR DESCRIPTION
The spotlight visibility issues persisted. This commit attempts to resolve them by:
- Setting the spotlight's world position to a fixed (0,2,0) as suggested by you, bringing it much closer to the presumed model location.
- Maintaining the spotlight's direction to target the dynamically calculated `modelCenter` of the loaded model.
- Keeping previously adjusted parameters:
  - Bright red color (1,0,0)
  - 15-degree angle
  - Intensity of 150
- A dim white hemispheric ambient light (intensity 0.2) remains to ensure overall scene visibility.